### PR TITLE
added support for activeViewsEnvOverride_ in getActiveViews()

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1333,7 +1333,16 @@ OCIO_NAMESPACE_ENTER
 
     const char * Config::getActiveViews() const
     {
-        getImpl()->activeViewsStr_ = JoinStringEnvStyle(getImpl()->activeViews_);
+        if(!getImpl()->activeViewsEnvOverride_.empty())
+        {
+            getImpl()->activeViewsStr_ = JoinStringEnvStyle(getImpl()->activeViewsEnvOverride_);
+        } 
+        else
+        {
+            getImpl()->activeViewsStr_ = JoinStringEnvStyle(getImpl()->activeViews_);
+        }
+
+        
         return getImpl()->activeViewsStr_.c_str();
     }
     


### PR DESCRIPTION
Even though this is a quick fix, I would love to see a more proper fix for this. I'm creating patches for Gentoo Linux, so I need to fix as many things as possible since upstream is neglecting this.