### PR TITLE
Fix define check for GCC symbol visibility

### DIFF
--- a/export/OpenColorIO/OpenColorABI.h.in
+++ b/export/OpenColorIO/OpenColorABI.h.in
@@ -69,7 +69,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // If supported, define OCIOEXPORT, OCIOHIDDEN
 // (used to choose which symbols to export from OpenColorIO)
-#if defined __linux__ || __APPLE__ || __FreeBSD__
+#if defined __GNUC__
     #if __GNUC__ >= 4
         #define OCIOEXPORT __attribute__ ((visibility("default")))
         #define OCIOHIDDEN __attribute__ ((visibility("hidden")))


### PR DESCRIPTION
Define the __attribute__ symbol visibility (for GCC) by checking
for GCC itself, instead of different OSes (which might also have
different compilers).

Clang should define __GNUC__ as well for GCC compatibility, so this
should cause no regressions (while fixing the symbols visibility on any
OS which uses GCC).